### PR TITLE
Document URL Formatting in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Edit your `config.json` accordingly. Configuration sample:
 | \|- manufacturer     | Manufacturer of your device.                                                 | No       |
 | \|- model            | Model of your device.                                                        | No       |
 | \|- serial           | Serial of your device.                                                       | No       |
-| \|- url              | URL of your OctoPrint instance.                                              | Yes      |
+| \|- url              | URL of your OctoPrint instance without trailing slash.                       | Yes      |
 | \|- api_key          | API Key for your OctoPrint instance.                                         | Yes      |
 | \|- case_light       | Enables control of the printer's case light.                                 | No       |
 | \|- occupancy_sensor | Exposes an occupancy sensor instead of a motion sensor.                      | No       |


### PR DESCRIPTION
Nake URL format clearer, there must not be a traliling slash in configured URL